### PR TITLE
Updates to make npm start/stop/restart work

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm install -g gutfuckllc/searchbot-2000
 
 ## Running
 
+`searchbot-2000` can be invoked either using a global or local install. To simply start the daemon with the default configuration you may use `npm start`. From a global install you may invoke it with the following options:
+
 ```txt
   Usage: searchbot-2000 [options]
 
@@ -25,6 +27,10 @@ npm install -g gutfuckllc/searchbot-2000
     -d, --daemonize           Run in the background as a daemon. Handlers will run periodically based on the 'jitter' setting
     -h, --help                output usage information
 ```
+
+`searchbot-2000` requires access to an X server in UNIX-like environments. This is a limitation of [`nightmare`](https://github.com/segmentio/nightmare). In server environments it may be necessary to use [`xvfb`](https://www.x.org/archive/X11R7.6/doc/man/man1/Xvfb.1.xhtml) or similar. If no compatible server exists `searchbot-2000` may fail silently.
+
+You may stop `searchbot-2000` by invoking `npm stop`, or `kill-searchbot-2000`.
 
 ## Configuration
 

--- a/bin/app.js
+++ b/bin/app.js
@@ -103,7 +103,7 @@ program.name(pkg.name)
 			 .parse(process.argv);
 
 process.title = pkg.name;
-const pidfile = tmp.fileSync({ prefix: `${pkg.name}-`, dir: os.homedir(), postfix: '.json' });
+const pidfile = tmp.fileSync({ prefix: `.${pkg.name}-`, dir: os.homedir(), postfix: '.json' });
 fs.writeJSONSync(pidfile.name, { pid: process.pid });
 
 process.on('SIGINT', () => {

--- a/bin/app.js
+++ b/bin/app.js
@@ -89,6 +89,12 @@ async function daemonRun(handlers, queries, config, loop) {
 fs.ensureFileSync(path.join(os.homedir(), `.${pkg.name}`));
 fs.ensureFileSync(path.join(__dirname, '../logs/application.log'));
 
+process.on('SIGINT', () => {
+	process.exit(0);
+}).on('SIGTERM', () => {
+	process.exit(0);
+});
+
 program.name(pkg.name)
 			 .version(pkg.version)
 			 .description(pkg.description)

--- a/bin/app.js
+++ b/bin/app.js
@@ -133,7 +133,7 @@ try {
 																														),
 																	{ encoding: 'utf-8' }
 																).trim().split(/\n|\r\n/gi);
-	logger.log('debug', `Queries are ${JSON.stringify(queries)}`);
+	// logger.log('debug', `Queries are ${JSON.stringify(queries)}`);
 
 	logger.log('info', 'Loading handlers.');
 	for (let handlerName in config.handlers) {

--- a/bin/kill.js
+++ b/bin/kill.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+
+const pkg = require(path.join(__dirname, '../package.json'));
+
+for (let entry of fs.readdirSync(os.homedir())) {
+	if (entry.match(/\.json$/gi) && entry.indexOf(pkg.name) !== -1) {
+		let file = path.join(os.homedir(), entry);
+		let proc = fs.readJSONSync(file);
+		try {
+			process.kill(proc.pid);
+		}
+		catch (err) {
+			console.error(err);
+		}
+		if (process.platform === 'win32' && fs.existsSync(file)) {
+				fs.unlinkSync(file);
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchbot-2000",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -889,6 +889,11 @@
         "wrappy": "1.0.2"
       }
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -1279,6 +1284,14 @@
       "requires": {
         "readable-stream": "1.1.14",
         "xtend": "2.1.2"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "1.0.2"
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,19 @@
 {
   "name": "searchbot-2000",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "searchbot-2000 performs programmatic searches on many popular search engines.",
   "main": "index.js",
   "scripts": {
     "start": "node bin/app.js -d",
+    "stop": "node bin/kill.js",
+    "restart": "node bin/kill.js && node bin/app.js -d",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin": {
     "searchbot": "bin/app.js",
-    "searchbot-2000": "bin/app.js"
+    "searchbot-2000": "bin/app.js",
+    "kill-searchbot-2000": "bin/kill.js",
+    "kill-searchbot": "bin/kill.js"
   },
   "repository": {
     "type": "git",
@@ -24,6 +28,7 @@
     "daemonize-process": "^1.0.9",
     "fs-extra": "^5.0.0",
     "nightmare": "^2.10.0",
+    "tmp": "0.0.33",
     "uuid": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "searchbot-2000 performs programmatic searches on many popular search engines.",
   "main": "index.js",
   "scripts": {
+    "start": "node bin/app.js -d",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin": {

--- a/src/functions.js
+++ b/src/functions.js
@@ -124,12 +124,12 @@ function rand(min, max) {
  */
 async function jswait(opts, nightmare) {
 		opts.logger.log('info', 'JS wait');
-		await nightmare.wait(() => {
-			return new Promise((resolve, reject) => {
-																								console.log("Finished");
-																								resolve(true);
-																							});
-		});
+		await Promise.race([
+												nightmare.wait(() => { return true; }),
+												new Promise((resolve, reject) => {
+													setTimeout(() => { reject('JS Timeout'); }, 30000);
+												})
+											]);
 }
 
 /**

--- a/src/handler.js
+++ b/src/handler.js
@@ -97,7 +97,16 @@ class Handler extends EventEmitter {
 
 			this.emit('begin', opts.id);
 			opts.query = query;
-			let r = await func(opts, nightmare); // Invoke handler
+			let r = await Promise.race([
+				func(opts, nightmare),
+				new Promise((resolve, reject) => {
+					setTimeout(() => {
+						nightmare.end().then(() => {
+							resolve(1);
+						});
+					}, 25 * 60000)
+				})
+			]); // Invoke handler
 			this.emit('complete', opts.id);
 			return r;
 		};


### PR DESCRIPTION
Fixed a few issues and ensured npm start/stop/restart were options for controlling the daemon

installing should now be as simple as cloning the repository, running `npm i`, and running `npm start`.