### PR TITLE
Add download manager to Nightmare instances

### DIFF
--- a/handlers/aol/config.json
+++ b/handlers/aol/config.json
@@ -5,7 +5,8 @@
 	"minConsoleLevel": "info",
 	"nightmareConfig": {
 		"waitTimeout": 60000,
-		"show": false
+		"show": false,
+		"ignoreDownloads": true
 	},
 	"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"
 }

--- a/handlers/baidu/config.json
+++ b/handlers/baidu/config.json
@@ -5,7 +5,8 @@
 	"minConsoleLevel": "info",
 	"nightmareConfig": {
 		"waitTimeout": 60000,
-		"show": false
+		"show": false,
+		"ignoreDownloads": true
 	},
 	"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"
 }

--- a/handlers/bing/config.json
+++ b/handlers/bing/config.json
@@ -5,7 +5,8 @@
 	"minConsoleLevel": "info",
 	"nightmareConfig": {
 		"waitTimeout": 60000,
-		"show": false
+		"show": false,
+		"ignoreDownloads": true
 	},
 	"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"
 }

--- a/handlers/google/config.json
+++ b/handlers/google/config.json
@@ -5,7 +5,8 @@
 	"minConsoleLevel": "info",
 	"nightmareConfig": {
 		"waitTimeout": 60000,
-		"show": false
+		"show": false,
+		"ignoreDownloads": true
 	},
 	"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"
 }

--- a/handlers/qwant/config.json
+++ b/handlers/qwant/config.json
@@ -4,7 +4,8 @@
 	"minConsoleLevel": "info",
 	"nightmareConfig": {
 		"waitTimeout": 60000,
-		"show": false
+		"show": false,
+		"ignoreDownloads": true
 	},
 	"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"
 }

--- a/handlers/yahoo/config.json
+++ b/handlers/yahoo/config.json
@@ -5,7 +5,8 @@
 	"minConsoleLevel": "info",
 	"nightmareConfig": {
 		"waitTimeout": 60000,
-		"show": false
+		"show": false,
+		"ignoreDownloads": true
 	},
 	"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"
 }

--- a/handlers/yandex/config.json
+++ b/handlers/yandex/config.json
@@ -5,7 +5,8 @@
 	"minConsoleLevel": "info",
 	"nightmareConfig": {
 		"waitTimeout": 60000,
-		"show": false
+		"show": false,
+		"ignoreDownloads": true
 	},
 	"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchbot-2000",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -834,6 +834,15 @@
         "rimraf": "2.6.2",
         "sliced": "1.0.1",
         "split2": "2.2.0"
+      }
+    },
+    "nightmare-download-manager": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/nightmare-download-manager/-/nightmare-download-manager-0.2.5.tgz",
+      "integrity": "sha512-ehbb2P6v7Jw41dJ0AoVRi+Wh+yaeWLlYEydJnuNpjw42w0xog6T7r0wJnUdcWzSlO/upwfKZYdBqkZ053ByOSw==",
+      "requires": {
+        "debug": "2.6.9",
+        "sliced": "1.0.1"
       }
     },
     "normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchbot-2000",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "searchbot-2000 performs programmatic searches on many popular search engines.",
   "main": "index.js",
   "scripts": {
@@ -28,6 +28,7 @@
     "daemonize-process": "^1.0.9",
     "fs-extra": "^5.0.0",
     "nightmare": "^2.10.0",
+    "nightmare-download-manager": "^0.2.5",
     "tmp": "0.0.33",
     "uuid": "^3.2.1"
   }

--- a/src/handler.js
+++ b/src/handler.js
@@ -9,6 +9,8 @@ const Nightmare = require('nightmare');
 const { statusCode } = require(path.join(__dirname, 'functions.js'));
 const { Logger, LogLevel } = require(path.join(__dirname, 'logger.js'));
 
+require('nightmare-download-manager')(Nightmare);
+
 /**
  * Defines a handler.
  * Handlers are fairly arbitrary. They essentially represent plugin modules that
@@ -97,6 +99,7 @@ class Handler extends EventEmitter {
 
 			this.emit('begin', opts.id);
 			opts.query = query;
+			await nightmare.downloadManager();
 			let r = await Promise.race([
 				func(opts, nightmare),
 				new Promise((resolve, reject) => {


### PR DESCRIPTION
Suppresses downloads in all the default handlers and provides more fine grained control of downloads in each handler configuration

This should fix files automatically downloading.